### PR TITLE
Begin to implement libre.fm support

### DIFF
--- a/Jellyfin.Plugin.Lastfm/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Lastfm/Configuration/configPage.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>Last.fm Scrobbler Configuration</title>
+    <title>Scrobbler Configuration</title>
 </head>
 
 <body>
@@ -13,8 +13,14 @@
             <div class="content-primary">
                 <form id="LastfmScrobblerConfigurationForm">
                     <div class="selectContainer">
-                        <select is="emby-select" id="user" name="user" label="Configure Last.fm for:"></select>
+                        <select is="emby-select" id="user" name="user" label="Configure User:"></select>
                     </div>
+                    <div class="inputContainer">
+                        <select is="emby-select" id="service" name="service" label="Scrobble to:"></select>
+                    </div>
+					<div class="inputContainer" id="customServerContainer" style="display:none;">
+						<input is="emby-input" id="customServer" name="customServer" type="text" label="Server URL:" />
+					</div>
                     <div class="inputContainer">
                         <input is="emby-input" id="username" name="username" type="text" label="Username:" />
                     </div>
@@ -57,6 +63,7 @@
                 _currentUserConfig: null,
 
                 configDefaults: {
+                    Service: '',
                     Username: '',
                     SessionKey: '',
                     MediaBrowserUserId: '',
@@ -119,6 +126,7 @@
                 populateInputs: function (userData) {
                     var data = $.extend({}, this.configDefaults, userData);
 
+                    this.$el.find('#service').val(data.Username);
                     this.$el.find('#username').val(data.Username);
                     this.$el.find('#password').val(data.SessionKey);
                     this.$el.find('#optionScrobble').prop('checked', data.Options.Scrobble);
@@ -230,7 +238,7 @@
                     var username = $(this).find("#username").val();
                     var password = $(this).find("#password").val();
 
-                    //Load the config again in case another user has updated their Lastfm info
+                    //Load the config again in case another user has updated their info
                     self.loadConfiguration().then(function () {
                         self.save(username, password);
                     });
@@ -241,6 +249,22 @@
             $('#LastfmScrobblerConfigurationPage').on('pageshow', function () {
                 LastfmScrobblerConfigurationPage.init($(this));
             });
+
+			const serviceSelect = document.querySelector('#service');
+
+			// populate options
+			['Last.fm', 'Libre.fm', 'Custom Server'].forEach((name, i) => {
+				const opt = document.createElement('option');
+				opt.value = ['lastfm', 'librefm', 'custom'][i];
+				opt.textContent = name;
+				serviceSelect.appendChild(opt);
+			});
+
+			// toggle custom input
+			serviceSelect.addEventListener('change', function () {
+				const container = document.querySelector('#customServerContainer');
+				container.style.display = this.value === 'custom' ? '' : 'none';
+			});
 
             //Add my own methods to the api client
             ApiClient.LastfmGetMobileSession = function (username, password) {
@@ -262,7 +286,10 @@
                     contentType: "application/json",
                     dataType: 'json'
                 });
-            };</script>
+            };
+
+
+		</script>
     </div>
 </body>
 

--- a/Jellyfin.Plugin.Lastfm/Plugin.cs
+++ b/Jellyfin.Plugin.Lastfm/Plugin.cs
@@ -31,7 +31,7 @@
             => "Last.fm";
 
         public override string Description
-            => "Scrobble your music collection to Last.fm";
+            => "Scrobble your music collection to Last.fm or Libre.fm";
 
         public static Plugin Instance { get; private set; }
 

--- a/Jellyfin.Plugin.Lastfm/Resources/Strings.cs
+++ b/Jellyfin.Plugin.Lastfm/Resources/Strings.cs
@@ -5,6 +5,7 @@
         public static class Endpoints
         {
             public static string LastfmApi  = "ws.audioscrobbler.com";
+            public static string LibrefmApi  = "libre.fm";
         }
 
         public static class Methods
@@ -23,6 +24,8 @@
         {
             public static string LastfmApiKey     = "cb3bdcd415fcb40cd572b137b2b255f5";
             public static string LastfmApiSeceret = "3a08f9fad6ddc4c35b0dce0062cecb5e";
+            public static string LibrefmApiKey    = "30jelliesinthesunwithbuttertoday";
+            public static string LibrefmApiSeceret= "";
         }
     }
 }


### PR DESCRIPTION
This is the beginning of my attempt to get libre.fm support working with this plugin so it can scrobble to both last.fm and libre.fm.

I've never written any js before, let alone developed a Jellyfin plugin, and I've never made a pull request before, but I mean- everyone does it for their first time. I want to figure out how to do this, and instead of asking for a feature I'm going to try and actually do the work.

This pull request is really incomplete but it DOES have an actual apikey for libre.fm. The dev of libre.fm has suggested the client code be ``jfn`` for the plugin.