### PR TITLE
Added an image to the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
         "overview": "A plugin that scrobbles your Jellyfin music to Last.fm",
         "owner": "danielfariati",
         "category": "music",
+        "imageUrl": "https://www.last.fm/static/images/lastfm_logo_facebook.png",
         "versions": [
             {
                 "version": "10.11.0.10",


### PR DESCRIPTION
Added a reference to a static logo url from last.fm.
This url is unlikely to ever get removed from their server, but if you have concerns about it, let me know and I can add it into the repository.

Preview:
<img width="275" height="252" alt="image" src="https://github.com/user-attachments/assets/fed6d171-1590-4321-ac27-db1c9db03faf" />